### PR TITLE
Fix reset of returncode by communicate() after process termination

### DIFF
--- a/testSolver.py
+++ b/testSolver.py
@@ -480,7 +480,7 @@ def terminate_process_and_children(process):
         except ProcessLookupError:
             pass  # The process does not exist anymore
 
-    return (process.communicate(), killed)
+    return ((process.stdout.read(), process.stderr.read()), killed)
 
 
 def run_solver_with_timeout(command, timeout):


### PR DESCRIPTION
Hi Tobias,

first of, I'm glad to see the regression suite is part of the MSE now, and the test script is very convenient to use, thanks a lot!
I think I've found a bug in the script though, but it's easy to fix.

When using the script with my anytime solver, it complains that for SATISFIABLE instances the return code is 0 but should be 10. I tried reproducing the problem with the commands provided by the `--verbose` switch and the reported timeout, together with the `timeout --preserve-status` command and got the correct return code 10.
This error (and, of course, a lot more) is also reported for a C program that should never exit with 0 (cf. below, attaching .c files is apparently not allowed).

[This stackoverflow post](https://stackoverflow.com/questions/48910693/python-subprocess-returns-wrong-exit-code) helped to identify the issue: In `terminate_process_and_children`, at some point, `process.terminate()` is called, and then `psutil.wait_procs(...)` is used to wait for termination.
[The latter function sets the `process.returncode` correctly](https://psutil.readthedocs.io/en/latest/index.html#psutil.wait_procs), but when [`process.communicate()`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate) is called later, the process has already terminated, and the `process.returncode` is overwritten with 0.

As a remedy, instead of using `process.communicate()` the `process.stdout` and `process.stderr` streams can be used.
They need to be `read` to strings for further processing (otherwise, for instance, `stderr.isspace()` will crash).

Greetings from Hamburg
Ole

```C
#include <signal.h>
#include <stdio.h>
#include <stdbool.h>

static volatile bool stop = false;

void handler(int signal) {
  ((void)signal);
  stop = true;
}

int main() {
  signal(SIGTERM, handler);
  signal(SIGINT, handler);
  printf("s SATISFIABLE\n");
  while (!stop) {}
  return 10;
}
```